### PR TITLE
Upstream code changed

### DIFF
--- a/lib/Parsedown/RubyTextTrait.php
+++ b/lib/Parsedown/RubyTextTrait.php
@@ -497,7 +497,7 @@ trait RubyTextTrait
         return $this->ruby_text_ExtensionEnabled;
     }
 
-    abstract public function line($text);
+    abstract public function line($text, $nonNestables=array());
     abstract protected function element(array $Element);
 
     protected $ruby_text_ElementBuilderName = 'buildRubyTextElementCallback';


### PR DESCRIPTION
Thanks a lot for your great job at first. `parsedown-rubytext` is very useful to me.

A recent version `parsedown(v1.7.1)` changed `line` function to
```php
public function line($text, $nonNestables=array())
```
So, it is necessary for `parsedown-rubytext` to change its abstract interface for consistency with upstream code.
